### PR TITLE
Change IO view label-button ratio to 7:3

### DIFF
--- a/ControlBeeWPF/Views/DigitalInputStatusBarViewV2.xaml
+++ b/ControlBeeWPF/Views/DigitalInputStatusBarViewV2.xaml
@@ -18,7 +18,7 @@
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Name="NameColumn" Width="{Binding NameColumnWidth, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
             <Border
                 Grid.Column="0"

--- a/ControlBeeWPF/Views/DigitalInputStatusBarViewV2.xaml.cs
+++ b/ControlBeeWPF/Views/DigitalInputStatusBarViewV2.xaml.cs
@@ -14,7 +14,7 @@ public partial class DigitalInputStatusBarViewV2 : IDisposable
         nameof(NameColumnWidth),
         typeof(GridLength),
         typeof(DigitalInputStatusBarViewV2),
-        new PropertyMetadata(new GridLength(90))
+        new PropertyMetadata(new GridLength(7, GridUnitType.Star))
     );
 
     public static readonly DependencyProperty RowHeightProperty = DependencyProperty.Register(

--- a/ControlBeeWPF/Views/DigitalOutputStatusBarViewV2.xaml
+++ b/ControlBeeWPF/Views/DigitalOutputStatusBarViewV2.xaml
@@ -18,7 +18,7 @@
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Name="NameColumn" Width="{Binding NameColumnWidth, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="3*" />
             </Grid.ColumnDefinitions>
             <Border
                 Grid.Column="0"

--- a/ControlBeeWPF/Views/DigitalOutputStatusBarViewV2.xaml.cs
+++ b/ControlBeeWPF/Views/DigitalOutputStatusBarViewV2.xaml.cs
@@ -15,7 +15,7 @@ public partial class DigitalOutputStatusBarViewV2 : IDisposable
         nameof(NameColumnWidth),
         typeof(GridLength),
         typeof(DigitalOutputStatusBarViewV2),
-        new PropertyMetadata(new GridLength(90))
+        new PropertyMetadata(new GridLength(7, GridUnitType.Star))
     );
 
     public static readonly DependencyProperty RowHeightProperty = DependencyProperty.Register(

--- a/ControlBeeWPF/Views/IoMonitorView.xaml.cs
+++ b/ControlBeeWPF/Views/IoMonitorView.xaml.cs
@@ -14,9 +14,9 @@ public partial class IoMonitorView
 {
     public static readonly DependencyProperty NameColumnWidthProperty = DependencyProperty.Register(
         nameof(NameColumnWidth),
-        typeof(double),
+        typeof(GridLength),
         typeof(IoMonitorView),
-        new PropertyMetadata(350.0, OnNameColumnWidthChanged)
+        new PropertyMetadata(new GridLength(7, GridUnitType.Star), OnNameColumnWidthChanged)
     );
 
     public static readonly DependencyProperty RowHeightProperty = DependencyProperty.Register(
@@ -36,7 +36,7 @@ public partial class IoMonitorView
         foreach (var (_, (_, ioListView)) in view._buttons)
         {
             if (ioListView is IoView ioView)
-                ioView.NameColumnWidth = (double)e.NewValue;
+                ioView.NameColumnWidth = (GridLength)e.NewValue;
         }
     }
 
@@ -54,9 +54,9 @@ public partial class IoMonitorView
         }
     }
 
-    public double NameColumnWidth
+    public GridLength NameColumnWidth
     {
-        get => (double)GetValue(NameColumnWidthProperty);
+        get => (GridLength)GetValue(NameColumnWidthProperty);
         set => SetValue(NameColumnWidthProperty, value);
     }
 

--- a/ControlBeeWPF/Views/IoView.xaml.cs
+++ b/ControlBeeWPF/Views/IoView.xaml.cs
@@ -17,9 +17,9 @@ public partial class IoView
 
     public static readonly DependencyProperty NameColumnWidthProperty = DependencyProperty.Register(
         nameof(NameColumnWidth),
-        typeof(double),
+        typeof(GridLength),
         typeof(IoView),
-        new PropertyMetadata(200.0, OnNameColumnWidthChanged)
+        new PropertyMetadata(new GridLength(7, GridUnitType.Star), OnNameColumnWidthChanged)
     );
 
     public static readonly DependencyProperty RowHeightProperty = DependencyProperty.Register(
@@ -49,9 +49,9 @@ public partial class IoView
         view.GoToOutputPage(view._outputPageIndex);
     }
 
-    public double NameColumnWidth
+    public GridLength NameColumnWidth
     {
-        get => (double)GetValue(NameColumnWidthProperty);
+        get => (GridLength)GetValue(NameColumnWidthProperty);
         set => SetValue(NameColumnWidthProperty, value);
     }
 
@@ -271,15 +271,11 @@ public partial class IoView
                         );
                         continue;
                     case DigitalInputStatusBarViewV2 digitalInputStatusBarViewV2:
-                        digitalInputStatusBarViewV2.NameColumnWidth = new GridLength(
-                            NameColumnWidth
-                        );
+                        digitalInputStatusBarViewV2.NameColumnWidth = NameColumnWidth;
                         digitalInputStatusBarViewV2.RowHeight = RowHeight;
                         break;
                     case DigitalOutputStatusBarViewV2 digitalOutputStatusBarViewV2:
-                        digitalOutputStatusBarViewV2.NameColumnWidth = new GridLength(
-                            NameColumnWidth
-                        );
+                        digitalOutputStatusBarViewV2.NameColumnWidth = NameColumnWidth;
                         digitalOutputStatusBarViewV2.RowHeight = RowHeight;
                         break;
                 }


### PR DESCRIPTION

<img width="1891" height="546" alt="image" src="https://github.com/user-attachments/assets/21ade29d-448f-4b0a-bd04-d476c0722452" />


What
- IoView의 IO 항목 라벨:버튼 비율을 7:3으로 변경

Why
- 현장 피드백: On/Off 버튼이 넓어서 라벨 이름이 잘리는 경우 발생

How
- NameColumnWidth 타입을 고정 px(double) → 비율(GridLength) 7:3으로 변경
- DigitalInput/OutputStatusBarViewV2, IoView, IoMonitorView에 공통 적용