### PR TITLE
Fix. check current jog type before sending _jogStop message in AxisControlView

### DIFF
--- a/ControlBeeWPF/Views/AxisControlView.xaml.cs
+++ b/ControlBeeWPF/Views/AxisControlView.xaml.cs
@@ -700,6 +700,8 @@ public partial class AxisControlView
 
     private void JogButton_OnMouseUp(object sender, MouseButtonEventArgs e)
     {
+        if (_currentJogType == JogType.Step)
+            return;
         var selectedAxis = _viewModel.SelectedAxis!;
         var actor = _actorRegistry.Get(selectedAxis.ActorName!)!;
         actor.Send(new ActorItemMessage(_ui, selectedAxis.ItemPath, "_jogStop"));


### PR DESCRIPTION
## Why

AxisControlView 에서 step move 할 때 지정된 step 만큼 이동 못하는 현상 확인

## What

AxisControlView 에서 step move 할 때 지정된 step 만큼 이동할 수 있도록

## How

Current jog type 확인하여 step 인 경우 _jogStop message 날리지 않도록 수정