### PR TITLE
Redesign LoginView and UserManagementView

### DIFF
--- a/ControlBeeWPF/Views/LoginView.xaml
+++ b/ControlBeeWPF/Views/LoginView.xaml
@@ -3,112 +3,195 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:ControlBeeWPF.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="Login"
-    Width="280"
-    Height="320"
+    Width="340"
+    AllowsTransparency="True"
+    Background="Transparent"
+    ResizeMode="NoResize"
+    SizeToContent="Height"
+    WindowStartupLocation="CenterScreen"
+    WindowStyle="None"
     mc:Ignorable="d">
 
+    <Window.Resources>
+        <Style x:Key="CardHeaderStyle" TargetType="Border">
+            <Setter Property="Background" Value="WhiteSmoke" />
+            <Setter Property="CornerRadius" Value="8,8,0,0" />
+            <Setter Property="Padding" Value="12,10" />
+        </Style>
+
+        <Style x:Key="CardHeaderTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="15" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+        </Style>
+
+        <Style x:Key="FieldLabelStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#FF555555" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Margin" Value="0,0,0,5" />
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="TextBox">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <ScrollViewer
+                                x:Name="PART_ContentHost"
+                                Focusable="False"
+                                HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Hidden" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF8AAED0" />
+                            </Trigger>
+                            <Trigger Property="IsFocused" Value="True">
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF6B92C0" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="38" />
+            <Setter Property="Background" Value="#FF4A7DC7" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="6"
+                            SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FF5A8DD7" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FF3A6DB7" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="SecondaryButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="38" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFF3F3F3" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF8AAED0" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFE0EAFF" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF6B92C0" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
     <Border
-        Margin="5"
-        Padding="15"
-        HorizontalAlignment="Stretch"
-        VerticalAlignment="Stretch"
-        CornerRadius="15">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="15" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="15" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="15" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+        Margin="10"
+        Background="White"
+        BorderBrush="#FFE0E0E0"
+        BorderThickness="1"
+        CornerRadius="8">
+        <Border.Effect>
+            <DropShadowEffect
+                BlurRadius="15"
+                Opacity="0.2"
+                ShadowDepth="2"
+                Color="Black" />
+        </Border.Effect>
 
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
+        <DockPanel>
+            <Border
+                DockPanel.Dock="Top"
+                MouseLeftButtonDown="Header_MouseLeftButtonDown"
+                Style="{StaticResource CardHeaderStyle}">
+                <TextBlock Style="{StaticResource CardHeaderTextStyle}" Text="Sign In" />
+            </Border>
 
-            <Grid.Resources>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Margin" Value="0,6,6,6" />
-                    <Setter Property="Foreground" Value="DimGray" />
-                    <Setter Property="FontSize" Value="15" />
-                    <Setter Property="VerticalAlignment" Value="Bottom" />
-                </Style>
-                <Style TargetType="TextBox">
-                    <Setter Property="Foreground" Value="Black" />
-                    <Setter Property="FontSize" Value="15" />
-                </Style>
-                <Style TargetType="Button">
-                    <Setter Property="Margin" Value="5" />
-                    <Setter Property="Height" Value="40" />
-                    <Setter Property="FontSize" Value="15" />
-                    <Setter Property="Foreground" Value="DarkSlateGray" />
-                    <Setter Property="FontWeight" Value="SemiBold" />
-                    <Setter Property="BorderBrush" Value="Silver" />
-                    <Setter Property="BorderThickness" Value="2" />
-                    <Setter Property="Background" Value="#FFE8E8E8" />
-                </Style>
-            </Grid.Resources>
+            <StackPanel Margin="28,28,28,32">
+                <TextBlock Style="{StaticResource FieldLabelStyle}" Text="ID" />
+                <TextBox Name="IdText" Text="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-            <TextBlock
-                Grid.Row="0"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                HorizontalAlignment="Center"
-                FontSize="20"
-                FontWeight="SemiBold"
-                Foreground="DimGray"
-                Text="Login" />
-            <Rectangle
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Height="1"
-                Fill="#FFBDBDBD" />
+                <TextBlock
+                    Margin="0,24,0,5"
+                    Style="{StaticResource FieldLabelStyle}"
+                    Text="Password" />
+                <TextBox Name="PasswordText" Text="{Binding UserPassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-            <TextBlock
-                Grid.Row="2"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Text="ID" />
-            <TextBox
-                Name="IdText"
-                Grid.Row="3"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Text="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <Grid Margin="0,32,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-            <TextBlock
-                Grid.Row="5"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Text="Password" />
-            <TextBox
-                Name="PasswordText"
-                Grid.Row="6"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                Text="{Binding UserPassword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button
+                        Grid.Column="0"
+                        Command="{Binding LoginCommand}"
+                        Content="Sign In"
+                        IsDefault="True"
+                        Style="{StaticResource PrimaryButtonStyle}" />
 
-            <Button
-                Grid.Row="8"
-                Grid.Column="0"
-                Command="{Binding LoginCommand}"
-                Content="Sign In"
-                IsDefault="True" />
-
-            <Button
-                Grid.Row="8"
-                Grid.Column="1"
-                Content="Cancel"
-                IsCancel="True" />
-        </Grid>
+                    <Button
+                        Grid.Column="2"
+                        Content="Cancel"
+                        IsCancel="True"
+                        Style="{StaticResource SecondaryButtonStyle}" />
+                </Grid>
+            </StackPanel>
+        </DockPanel>
     </Border>
 </Window>

--- a/ControlBeeWPF/Views/LoginView.xaml.cs
+++ b/ControlBeeWPF/Views/LoginView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Input;
 using ControlBeeWPF.ViewModels;
 
 namespace ControlBeeWPF.Views;
@@ -14,5 +15,10 @@ public partial class LoginView : Window
         DataContext = viewModel;
 
         viewModel.LoginSucceeded += (_, _) => DialogResult = true;
+    }
+
+    private void Header_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        DragMove();
     }
 }

--- a/ControlBeeWPF/Views/UserManagementView.xaml
+++ b/ControlBeeWPF/Views/UserManagementView.xaml
@@ -4,122 +4,292 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="User Management"
     Width="1100"
     Height="700"
+    Background="#FFF5F5F5"
+    WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
 
     <Window.Resources>
-        <SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}" Color="White" />
+        <Style x:Key="CardStyle" TargetType="Border">
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderBrush" Value="#FFE0E0E0" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Margin" Value="6" />
+        </Style>
+
+        <Style x:Key="CardHeaderStyle" TargetType="Border">
+            <Setter Property="Background" Value="WhiteSmoke" />
+            <Setter Property="CornerRadius" Value="6,6,0,0" />
+            <Setter Property="Padding" Value="14,10" />
+        </Style>
+
+        <Style x:Key="CardHeaderTextStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="14" />
+        </Style>
+
+        <Style x:Key="FieldLabelStyle" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#FF555555" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Margin" Value="0,0,0,5" />
+        </Style>
+
+        <Style TargetType="TextBox">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="TextBox">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <ScrollViewer
+                                x:Name="PART_ContentHost"
+                                Focusable="False"
+                                HorizontalScrollBarVisibility="Hidden"
+                                VerticalScrollBarVisibility="Hidden" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF8AAED0" />
+                            </Trigger>
+                            <Trigger Property="IsFocused" Value="True">
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF6B92C0" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style TargetType="ComboBox">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="8,6" />
+        </Style>
+
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="38" />
+            <Setter Property="Background" Value="#FF4A7DC7" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="6"
+                            SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FF5A8DD7" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FF3A6DB7" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DangerButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="28" />
+            <Setter Property="Width" Value="28" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                            <Path
+                                x:Name="icon"
+                                Width="14"
+                                Height="14"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Data="M3,6 L3,14 C3,15.1 3.9,16 5,16 L11,16 C12.1,16 13,15.1 13,14 L13,6 L3,6 Z M5,8 L6,8 L6,14 L5,14 L5,8 Z M7.5,8 L8.5,8 L8.5,14 L7.5,14 L7.5,8 Z M10,8 L11,8 L11,14 L10,14 L10,8 Z M13.5,3 L10.5,3 L10,2 L6,2 L5.5,3 L2.5,3 L2.5,5 L13.5,5 L13.5,3 Z"
+                                Fill="#FFBBBBBB"
+                                Stretch="Uniform" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFFDEAEA" />
+                                <Setter TargetName="icon" Property="Fill" Value="#FFD04A4A" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFF5D0D0" />
+                                <Setter TargetName="icon" Property="Fill" Value="#FFB03A3A" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="SecondaryButtonStyle" TargetType="Button">
+            <Setter Property="Height" Value="38" />
+            <Setter Property="Background" Value="White" />
+            <Setter Property="Foreground" Value="#FF333333" />
+            <Setter Property="BorderBrush" Value="#FFCCCCCC" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border
+                            x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="6"
+                            SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFF3F3F3" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF8AAED0" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#FFE0EAFF" />
+                                <Setter TargetName="border" Property="BorderBrush" Value="#FF6B92C0" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style TargetType="DataGrid">
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="GridLinesVisibility" Value="Horizontal" />
+            <Setter Property="HorizontalGridLinesBrush" Value="#FFF0F0F0" />
+            <Setter Property="RowHeaderWidth" Value="0" />
+            <Setter Property="FontSize" Value="13" />
+        </Style>
+
+        <Style TargetType="DataGridColumnHeader">
+            <Setter Property="Background" Value="#FFF8F8F8" />
+            <Setter Property="Foreground" Value="#FF555555" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Padding" Value="10,8" />
+            <Setter Property="BorderBrush" Value="#FFE8E8E8" />
+            <Setter Property="BorderThickness" Value="0,0,1,1" />
+        </Style>
+
+        <Style TargetType="DataGridRow">
+            <Setter Property="Background" Value="White" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#FFF5F8FF" />
+                </Trigger>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="#FFE0EAFF" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style TargetType="DataGridCell">
+            <Setter Property="Padding" Value="8,4" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="DataGridCell">
+                        <Border
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderThickness="0">
+                            <ContentPresenter VerticalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Foreground" Value="#FF333333" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="EllipsisWithTooltip" TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="TextWrapping" Value="NoWrap" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+            <Setter Property="ToolTip" Value="{Binding Text, RelativeSource={RelativeSource Self}}" />
+        </Style>
     </Window.Resources>
 
-    <Grid>
+    <Grid Margin="8">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="7*" />
             <ColumnDefinition Width="3*" />
         </Grid.ColumnDefinitions>
 
-        <Grid.Resources>
-            <Style TargetType="Border">
-                <Setter Property="BorderBrush" Value="DimGray" />
-                <Setter Property="BorderThickness" Value="1" />
-                <Setter Property="Margin" Value="5" />
-                <Setter Property="Padding" Value="10" />
-            </Style>
+        <Border Grid.Column="0" Style="{StaticResource CardStyle}">
+            <DockPanel>
+                <Border DockPanel.Dock="Top" Style="{StaticResource CardHeaderStyle}">
+                    <TextBlock Style="{StaticResource CardHeaderTextStyle}" Text="User Management" />
+                </Border>
 
-            <Style TargetType="Button">
-                <Setter Property="Margin" Value="20" />
-                <Setter Property="Height" Value="50" />
-                <Setter Property="FontSize" Value="15" />
-                <Setter Property="Foreground" Value="DarkSlateGray" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="BorderBrush" Value="Silver" />
-                <Setter Property="BorderThickness" Value="2" />
-                <Setter Property="Background" Value="#FFC4E3FF" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-            </Style>
-
-            <Style x:Key="RoundedButtonStyle" TargetType="Button">
-                <Setter Property="Margin" Value="20" />
-                <Setter Property="Height" Value="50" />
-                <Setter Property="FontSize" Value="15" />
-                <Setter Property="Foreground" Value="DarkSlateGray" />
-                <Setter Property="FontWeight" Value="SemiBold" />
-                <Setter Property="Cursor" Value="Hand" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border
-                                x:Name="Root"
-                                Padding="10,5"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="Silver"
-                                BorderThickness="1"
-                                CornerRadius="8">
-                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="Root" Property="Margin" Value="0,5,0,0" />
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-        </Grid.Resources>
-
-        <Border Name="UserListBorder" Grid.Column="0">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-
-                <TextBlock
-                    Grid.Row="0"
-                    Margin="5"
-                    HorizontalAlignment="Center"
-                    FontSize="25"
-                    FontWeight="SemiBold"
-                    Foreground="DimGray"
-                    Text="User Management" />
-                <Rectangle
-                    Grid.Row="1"
-                    Height="1"
-                    Margin="20"
-                    Fill="#FFBDBDBD" />
+                <Border
+                    Padding="12,8"
+                    Background="#FFFAFAFA"
+                    BorderBrush="#FFE0E0E0"
+                    BorderThickness="0,1,0,0"
+                    CornerRadius="0,0,6,6"
+                    DockPanel.Dock="Bottom">
+                    <Button
+                        Width="160"
+                        HorizontalAlignment="Right"
+                        Command="{Binding UpdateUsersCommand}"
+                        Content="Update"
+                        Style="{StaticResource PrimaryButtonStyle}" />
+                </Border>
 
                 <DataGrid
-                    Grid.Row="2"
+                    Margin="4"
                     AutoGenerateColumns="False"
-                    Background="White"
-                    FontSize="16"
                     HorizontalScrollBarVisibility="Auto"
                     IsReadOnly="False"
                     ItemsSource="{Binding Users}"
-                    RowHeight="40"
+                    RowHeight="38"
                     SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
                     SelectionMode="Single"
                     SelectionUnit="FullRow"
                     VerticalScrollBarVisibility="Auto">
-                    <DataGrid.Resources>
-                        <Style x:Key="EllipsisWithTooltip" TargetType="TextBlock">
-                            <Setter Property="VerticalAlignment" Value="Center" />
-                            <Setter Property="TextWrapping" Value="NoWrap" />
-                            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
-                            <Setter Property="ToolTip" Value="{Binding Text, RelativeSource={RelativeSource Self}}" />
-                        </Style>
-                        <Style TargetType="DataGridCell">
-                            <Setter Property="VerticalContentAlignment" Value="Center" />
-                        </Style>
-                        <Style TargetType="ScrollBar">
-                            <Setter Property="Width" Value="30" />
-                        </Style>
-                    </DataGrid.Resources>
-
                     <DataGrid.Columns>
                         <DataGridTextColumn
                             Width="50"
@@ -152,6 +322,20 @@
                                 <Style TargetType="TextBox">
                                     <Setter Property="TextWrapping" Value="Wrap" />
                                     <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                                    <Setter Property="Padding" Value="2" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="TextBox">
+                                                <Border
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="#FF6B92C0"
+                                                    BorderThickness="1"
+                                                    CornerRadius="2">
+                                                    <ScrollViewer x:Name="PART_ContentHost" />
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
                                 </Style>
                             </DataGridTextColumn.EditingElementStyle>
                         </DataGridTextColumn>
@@ -167,6 +351,20 @@
                                 <Style TargetType="TextBox">
                                     <Setter Property="TextWrapping" Value="NoWrap" />
                                     <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+                                    <Setter Property="Padding" Value="2" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="TextBox">
+                                                <Border
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="#FF6B92C0"
+                                                    BorderThickness="1"
+                                                    CornerRadius="2">
+                                                    <ScrollViewer x:Name="PART_ContentHost" />
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
                                 </Style>
                             </DataGridTextColumn.EditingElementStyle>
                         </DataGridTextColumn>
@@ -190,117 +388,62 @@
                             </DataGridTextColumn.ElementStyle>
                         </DataGridTextColumn>
 
-                        <DataGridTemplateColumn Width="50" Header="Delete">
+                        <DataGridTemplateColumn Width="50" Header="">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Button
-                                        Height="25"
-                                        Margin="0"
-                                        Background="Red"
                                         Command="{Binding DataContext.DeleteCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                        CommandParameter="{Binding Id}" />
+                                        CommandParameter="{Binding Id}"
+                                        Style="{StaticResource DangerButtonStyle}" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
-
-                <Button
-                    Grid.Row="3"
-                    Width="210"
-                    Height="50"
-                    HorizontalAlignment="Right"
-                    Background="#FFD0FFD0"
-                    Command="{Binding UpdateUsersCommand}"
-                    Content="Update"
-                    Style="{StaticResource RoundedButtonStyle}" />
-            </Grid>
+            </DockPanel>
         </Border>
 
-        <Border Name="RegisterBorder" Grid.Column="1">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="40" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
+        <Border Grid.Column="1" Style="{StaticResource CardStyle}">
+            <DockPanel>
+                <Border DockPanel.Dock="Top" Style="{StaticResource CardHeaderStyle}">
+                    <TextBlock Style="{StaticResource CardHeaderTextStyle}" Text="Register" />
+                </Border>
 
-                <Grid.Resources>
-                    <Style TargetType="TextBlock">
-                        <Setter Property="Margin" Value="5" />
-                        <Setter Property="Foreground" Value="DimGray" />
-                        <Setter Property="FontSize" Value="15" />
-                        <Setter Property="VerticalAlignment" Value="Bottom" />
-                    </Style>
-                    <Style TargetType="TextBox">
-                        <Setter Property="Margin" Value="5" />
-                        <Setter Property="Foreground" Value="Black" />
-                        <Setter Property="FontSize" Value="20" />
-                    </Style>
-                    <Style TargetType="ComboBox">
-                        <Setter Property="Margin" Value="5" />
-                        <Setter Property="Foreground" Value="Black" />
-                        <Setter Property="Background" Value="White" />
-                        <Setter Property="FontSize" Value="20" />
-                    </Style>
-                </Grid.Resources>
+                <StackPanel Margin="20,20,20,24">
+                    <TextBlock Style="{StaticResource FieldLabelStyle}" Text="Name" />
+                    <TextBox Name="NameText" Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock
-                    Grid.Row="0"
-                    HorizontalAlignment="Center"
-                    FontSize="25"
-                    FontWeight="SemiBold"
-                    Foreground="DimGray"
-                    Text="Register" />
-                <Rectangle
-                    Grid.Row="1"
-                    Height="1"
-                    Margin="20"
-                    Fill="#FFBDBDBD" />
+                    <TextBlock
+                        Margin="0,18,0,5"
+                        Style="{StaticResource FieldLabelStyle}"
+                        Text="ID" />
+                    <TextBox Name="IdText" Text="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock Grid.Row="2" Text="Name" />
-                <TextBox
-                    Name="NameText"
-                    Grid.Row="3"
-                    Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock
+                        Margin="0,18,0,5"
+                        Style="{StaticResource FieldLabelStyle}"
+                        Text="Password" />
+                    <TextBox Name="PasswordText" Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock Grid.Row="4" Text="ID" />
-                <TextBox
-                    Name="IdText"
-                    Grid.Row="5"
-                    Text="{Binding UserId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    <TextBlock
+                        Margin="0,18,0,5"
+                        Style="{StaticResource FieldLabelStyle}"
+                        Text="Level" />
+                    <ComboBox
+                        Name="LevelComboBox"
+                        DisplayMemberPath="Value"
+                        IsEditable="True"
+                        ItemsSource="{Binding LevelItems}"
+                        SelectedValue="{Binding UserLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        SelectedValuePath="Key" />
 
-                <TextBlock Grid.Row="6" Text="Password" />
-                <TextBox
-                    Name="PasswordText"
-                    Grid.Row="7"
-                    Text="{Binding Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-
-                <TextBlock Grid.Row="8" Text="Level" />
-                <ComboBox
-                    Name="LevelComboBox"
-                    Grid.Row="9"
-                    DisplayMemberPath="Value"
-                    IsEditable="True"
-                    ItemsSource="{Binding LevelItems}"
-                    SelectedValue="{Binding UserLevel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    SelectedValuePath="Key" />
-
-                <Button
-                    Grid.Row="10"
-                    Background="#FFE5F3FF"
-                    Command="{Binding RegisterCommand}"
-                    Content="Register"
-                    Style="{StaticResource RoundedButtonStyle}" />
-            </Grid>
+                    <Button
+                        Margin="0,28,0,0"
+                        Command="{Binding RegisterCommand}"
+                        Content="Register"
+                        Style="{StaticResource PrimaryButtonStyle}" />
+                </StackPanel>
+            </DockPanel>
         </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
# [What]
LoginView와 UserManagementView Redesign

# [Why]
이전의 UI Design이 너무 심플해서 수정

# [UI]
## LoginView
#### Before
<img width="357" height="427" alt="image" src="https://github.com/user-attachments/assets/7c431589-637a-4abf-a778-74a02704972f" />

#### After
<img width="435" height="412" alt="image" src="https://github.com/user-attachments/assets/94644738-2b15-4013-b1be-aeaf137b26ce" />

## UserManagementView
#### Before
<img width="1418" height="901" alt="image" src="https://github.com/user-attachments/assets/94b3cee0-15dd-4fd8-a4a0-b8f5bb11e316" />

#### After
<img width="1397" height="903" alt="image" src="https://github.com/user-attachments/assets/95563e49-b96c-4c6e-a553-965f5db9696b" />
