### PR TITLE
Support move button to PositionVariableListView

### DIFF
--- a/ControlBeeWPF/ViewModels/PositionVariableListViewModel.cs
+++ b/ControlBeeWPF/ViewModels/PositionVariableListViewModel.cs
@@ -43,6 +43,22 @@ public sealed class PositionVariableListViewModel(IActorRegistry actorRegistry)
         Rows.Add(new Row(rowName, keys, axisStatusViewModels, variableViewModels, axisItemPaths));
     }
 
+    public void MoveToPosition(Row row)
+    {
+        foreach (var positionVariableItemKey in row.PositionVariableItemKeys)
+        {
+            var actor = actorRegistry.Get(positionVariableItemKey.ActorName);
+            actor?.Send(
+                new VariableActorItemMessage(
+                    _uiActor,
+                    positionVariableItemKey.ItemPath,
+                    positionVariableItemKey.SubItemPath,
+                    "MoveToSavedPos"
+                )
+            );
+        }
+    }
+
     public void SetPosition(Row row)
     {
         foreach (var positionVariableItemKey in row.PositionVariableItemKeys)

--- a/ControlBeeWPF/Views/PositionVariableListView.xaml
+++ b/ControlBeeWPF/Views/PositionVariableListView.xaml
@@ -10,9 +10,6 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
-        <Style TargetType="views:VariableItemView">
-            <Setter Property="BorderMargin" Value="2 0" />
-        </Style>
         <Style x:Key="MainLabelStyle" TargetType="Label">
             <Setter Property="Background" Value="WhiteSmoke" />
             <Setter Property="Foreground" Value="Black" />

--- a/ControlBeeWPF/Views/PositionVariableListView.xaml.cs
+++ b/ControlBeeWPF/Views/PositionVariableListView.xaml.cs
@@ -75,11 +75,15 @@ public partial class PositionVariableListView
         grid.ColumnDefinitions.Add(
             new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "SetButton" }
         );
+        grid.ColumnDefinitions.Add(
+            new ColumnDefinition { Width = GridLength.Auto, SharedSizeGroup = "MoveButton" }
+        );
         return grid;
     }
 
     private int AxisColumnOffset => 2;
     private int SetButtonColumn => 2 + _axisLabels.Length + 1;
+    private int MoveButtonColumn => SetButtonColumn + 1;
 
     private void RenderHeader()
     {
@@ -140,6 +144,7 @@ public partial class PositionVariableListView
                     continue;
 
                 var view = _viewFactory.Create<VariableItemView>(variableViewModel)!;
+                view.BorderMargin = new Thickness(2, 0, 2, 0);
                 view.DisplayConverter = valueObject =>
                     valueObject is double doubleValue ? doubleValue.ToString("F3") : valueObject;
                 view.Refresh();
@@ -147,14 +152,23 @@ public partial class PositionVariableListView
                 grid.Children.Add(view);
             }
 
-            var button = new Button
+            var setButton = new Button
             {
                 Content = "Set",
                 Style = (Style)FindResource("RoundButtonStyle"),
             };
-            button.Click += (_, _) => SetPosition(row);
-            Grid.SetColumn(button, SetButtonColumn);
-            grid.Children.Add(button);
+            setButton.Click += (_, _) => SetPosition(row);
+            Grid.SetColumn(setButton, SetButtonColumn);
+            grid.Children.Add(setButton);
+
+            var moveButton = new Button
+            {
+                Content = "Move",
+                Style = (Style)FindResource("RoundButtonStyle"),
+            };
+            moveButton.Click += (_, _) => MoveToPosition(row);
+            Grid.SetColumn(moveButton, MoveButtonColumn);
+            grid.Children.Add(moveButton);
 
             RowsControl.Items.Add(grid);
         }
@@ -173,5 +187,21 @@ public partial class PositionVariableListView
             return;
 
         _viewModel.SetPosition(row);
+    }
+
+    private void MoveToPosition(PositionVariableListViewModel.Row row)
+    {
+        if (
+            MessageBox.Show(
+                "Do you want to move to saved position?",
+                "Move to position",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question,
+                MessageBoxResult.No
+            ) == MessageBoxResult.No
+        )
+            return;
+
+        _viewModel.MoveToPosition(row);
     }
 }


### PR DESCRIPTION
## Why
- 기존 `PositionVariableListView`는 현재 위치를 저장하는 **Set** 기능만 있고, 저장된 위치로 이동시키는 **Move** 기능이 없음. 사용자가 다른 화면에서 이동을 따로 트리거해야 했음.
- Move 버튼이 추가되면서 행 폭이 늘어나, 외부 UserControl 레이아웃에서 행이 잘려 보일 수 있음. 외부에서 `VariableItemView`의 크기/마진을 줄여 행을 맞출 수 있어야 하는데, 내부 implicit Style(`<Style TargetType="views:VariableItemView">`)이 visual tree로 전파되어 외부 style policy를 막고 있었음.

## What
- 각 행에 **Move** 버튼 추가.
- Move 클릭 시 저장된 위치로 이동할지 확인 다이얼로그 표시.
- `VariableItemView`의 implicit Style 제거. 필요한 `BorderMargin`은 인스턴스 단위로 지정.

## How
- **ViewModel** (`PositionVariableListViewModel.MoveToPosition`)
  - 행에 속한 모든 PositionVariableItemKey에 대해 actor로 VariableActorItemMessage(..., "MoveToSavedPos") 전송.
  - 실제 모션은 ControlBee 쪽에서 axes list를 순차 MoveAndWait로 처리. View/ViewModel은 메시지 전달만 담당.
- **View** (`PositionVariableListView.xaml.cs`)
  - SetButton 과 동일하게 Row Grid에 MoveButton SharedSizeGroup 컬럼 추가, SetButtonColumn 다음에 Move 버튼 배치.
  - 확인 다이얼로그는 MessageBoxResult.No 를 default로 지정. 키보드 오입력으로 의도치 않은 모션 방지.
- **Style 정리** (`PositionVariableListView.xaml`, `.xaml.cs`)
  - <Style TargetType="views:VariableItemView"> 블록 제거.
  - RenderRows 에서 각 VariableItemView 에 직접 view.BorderMargin = new Thickness(2, 0, 2, 0) 지정. 외부 UserControl이 자체 Style로 폭/마진을 조정해 행 잘림을 방지할 수 있음.