### PR TITLE
Fix AxisControlView Direction.png to assembly-qualified pack URI

### DIFF
--- a/ControlBeeWPF/Views/AxisControlView.xaml
+++ b/ControlBeeWPF/Views/AxisControlView.xaml
@@ -782,7 +782,7 @@
                                 PreviewMouseRightButtonDown="JogButton_OnMouseRightButtonDown"
                                 PreviewMouseUp="JogButton_OnMouseUp"
                                 Style="{StaticResource JogButtonStyle}">
-                                <Image Source="/Images/Direction.png" />
+                                <Image Source="/ControlBeeWPF;component/Images/Direction.png" />
                             </Button>
                             <Button
                                 Name="LeftButton"
@@ -792,7 +792,7 @@
                                 PreviewMouseRightButtonDown="JogButton_OnMouseRightButtonDown"
                                 PreviewMouseUp="JogButton_OnMouseUp"
                                 Style="{StaticResource JogButtonStyle}">
-                                <Image RenderTransformOrigin="0.5,0.5" Source="/Images/Direction.png">
+                                <Image RenderTransformOrigin="0.5,0.5" Source="/ControlBeeWPF;component/Images/Direction.png">
                                     <Image.RenderTransform>
                                         <RotateTransform Angle="-90" />
                                     </Image.RenderTransform>
@@ -806,7 +806,7 @@
                                 PreviewMouseRightButtonDown="JogButton_OnMouseRightButtonDown"
                                 PreviewMouseUp="JogButton_OnMouseUp"
                                 Style="{StaticResource JogButtonStyle}">
-                                <Image RenderTransformOrigin="0.5,0.5" Source="/Images/Direction.png">
+                                <Image RenderTransformOrigin="0.5,0.5" Source="/ControlBeeWPF;component/Images/Direction.png">
                                     <Image.RenderTransform>
                                         <RotateTransform Angle="180" />
                                     </Image.RenderTransform>
@@ -820,7 +820,7 @@
                                 PreviewMouseRightButtonDown="JogButton_OnMouseRightButtonDown"
                                 PreviewMouseUp="JogButton_OnMouseUp"
                                 Style="{StaticResource JogButtonStyle}">
-                                <Image RenderTransformOrigin="0.5,0.5" Source="/Images/Direction.png">
+                                <Image RenderTransformOrigin="0.5,0.5" Source="/ControlBeeWPF;component/Images/Direction.png">
                                     <Image.RenderTransform>
                                         <RotateTransform Angle="90" />
                                     </Image.RenderTransform>


### PR DESCRIPTION
# What, How
- AxisControlView jog 버튼 4개의 방향 이미지 URI를 어셈블리 한정 pack URI로 수정: `Source="/Images/Direction.png"` → `Source="/ControlBeeWPF;component/Images/Direction.png"`

# Why
- 어셈블리 지정이 없는 `/Images/...` 경로는 라이브러리가 아니라 실행 앱(exe)의 리소스에서 찾기 때문에, 앱에 이미지 사본이 없으면 jog 버튼이 빈 버튼으로 나옴 (C사 5000은 Direction.png 사본을 직접 프로젝트에 넣어서 표시했음)
- InitializationView가 이미 쓰고 있는 `/ControlBeeWPF;component/...` 방식으로 통일