### PR TITLE
Add UseContinuous option to InspectionContainerView

### DIFF
--- a/ControlBeeWPF/Views/InspectionContainerView.xaml.cs
+++ b/ControlBeeWPF/Views/InspectionContainerView.xaml.cs
@@ -69,6 +69,8 @@ public partial class InspectionContainerView : IRefreshable, INotifyPropertyChan
         }
     }
 
+    public bool UseContinuous { get; set; } = true;
+
     public IntPtr HostHandle => HostControl.Child.Handle;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -76,7 +78,11 @@ public partial class InspectionContainerView : IRefreshable, INotifyPropertyChan
     public void Refresh()
     {
         _viewModel.EmbedVisionCommand.Execute((HostHandle, _options));
-        if (_mode == "VisionFrame" && _options.GetValueOrDefault("Channel") is int channel)
+        if (
+            _mode == "VisionFrame"
+            && UseContinuous
+            && _options.GetValueOrDefault("Channel") is int channel
+        )
             _viewModel.StartContinuousCommand.Execute(channel);
     }
 


### PR DESCRIPTION
## Why

- `InspectionContainerView`는 `Mode`가 `VisionFrame`이고 `Channel` 옵션이 지정되어 있으면 `Refresh()`에서 무조건 `StartContinuousCommand`를 실행함.
- `Refresh()`는 `Loaded` 이벤트와 채널 버튼 클릭에서 호출되므로, 뷰가 visual tree에 붙을 때마다 continuous grab이 시작됨. 화면을 나갔다 다시 들어와도 매번 재실행됨.
- 소비 프로젝트가 이 동작을 끌 방법이 없음. 시퀀스가 trigger하는 검사와 continuous grab이 같은 채널을 두고 경쟁하는 상황(auto 운전 중)에서도 막을 수 없음.
- 소비 프로젝트에서 상황에 맞게 UseContinuous 를 설정하여 (예를 들어 _auto 인 경우) 불필요한 상황에 Continuous 가 호출되어 CameraModel 에서 경합이 생기는 케이스를 방지

## What

- **InspectionContainerView**: `UseContinuous` property 추가. `false`면 `Refresh()`가 `StartContinuousCommand`를 실행하지 않음.

기본값이 `true`이므로 값을 세팅하지 않는 기존 소비 프로젝트는 동작 변화 없음.

**FYI:** `UseContinuous`를 `false`로 바꿔도 이미 진행 중인 continuous grab을 중지시키지는 않음. `Refresh()` 시점에 시작할지만 결정함.

## How

### Refresh 시점의 게이트로 한정

property setter에서 즉시 start/stop을 적용하지 않는 이유는, `Loaded` 이전에 setter가 호출되면 vision view가 embed되기 전에 device로 요청이 나가므로 그것을 따로 막아야 하기 때문. 판단을 `Refresh()` 한 곳에 두면 `EmbedVisionCommand` 직후라는 시점이 보장됨.

```csharp
public bool UseContinuous { get; set; } = true;

public void Refresh()
{
    _viewModel.EmbedVisionCommand.Execute((HostHandle, _options));
    if (
        _mode == "VisionFrame"
        && UseContinuous
        && _options.GetValueOrDefault("Channel") is int channel
    )
        _viewModel.StartContinuousCommand.Execute(channel);
}
```

- 변경 통지가 없는 auto-property로 둠. `Refresh()` 시점에만 읽히므로 `PropertyChanged`가 필요하지 않고, `ActiveChannel`처럼 뷰 내부 상태를 외부에 알리는 용도도 아님.
